### PR TITLE
Add library.properties metadata file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,9 @@
+name=Adjutant
+version=0.0.1
+author=Konrad R.K. Ludwig
+maintainer=Konrad R.K. Ludwig
+sentence=Control the Scintilla air quality monitoring device.
+paragraph=
+category=Device Control
+url=https://github.com/scintilla-aircheck/adjutant
+architectures=esp8266


### PR DESCRIPTION
Libraries in the Arduino Library 1.5 format (source files under the src subfolder) are required to have a library.properties file in the root folder. If this file is not present the library is not recognized by the Arduino IDE.

This file is also required for inclusion in the Arduino Library Manager index.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#library-metadata